### PR TITLE
Add feature-gated derive of serde Serialize/Deserialize

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,23 +1,23 @@
 [package]
-name = "read-structure"
-version = "0.1.1-alpha.0"
-edition = "2021"
-authors = [
-    "Nils Homer <nils@fulcrumgenomics.com>",
-    "Seth Stadick <seth@fulcrumgenomics.com>"
-]
-license = "MIT"
-readme = "README.md"
-documentation = "https://docs.rs/read-structure"
-homepage = "https://github.com/fulcrumgenomics/read-structure"
-repository = "https://github.com/fulcrumgenomics/read-structure"
-description = "Library for parsing and working with read structure descriptions"
-keywords = ["bioinformatics", "genomic"]
+authors = ["Nils Homer <nils@fulcrumgenomics.com>", "Seth Stadick <seth@fulcrumgenomics.com>"]
 categories = ["science"]
-
+description = "Library for parsing and working with read structure descriptions"
+documentation = "https://docs.rs/read-structure"
+edition = "2021"
+homepage = "https://github.com/fulcrumgenomics/read-structure"
+keywords = ["bioinformatics", "genomic"]
+license = "MIT"
+name = "read-structure"
+readme = "README.md"
+repository = "https://github.com/fulcrumgenomics/read-structure"
+version = "0.1.1-alpha.0"
 
 [dependencies]
 bstr = "0.2.17"
+serde = { version = "1.0.163", features = ["derive"], optional = true } 
 strum = "0.24"
 strum_macros = "0.24"
 thiserror = "1.0.30"
+
+[dev-dependencies]
+serde_json = "1.0.96"

--- a/src/read_segment.rs
+++ b/src/read_segment.rs
@@ -21,6 +21,7 @@ pub const ANY_LENGTH_STR: &str = "+";
 /// The read segment describing a given kind ([`SegmentType`]), optional length, and offset of the
 /// bases within a [`crate::read_structure::ReadStructure`].
 #[derive(Debug, Copy, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ReadSegment {
     /// The offset in the read if the segment belongs to a read structure
     pub(crate) offset: usize,

--- a/src/read_structure.rs
+++ b/src/read_structure.rs
@@ -17,7 +17,8 @@ use std::string;
 use std::string::ToString;
 
 /// The read structure composed of one or more [`ReadSegment`]s.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ReadStructure {
     /// The elements that make up the [`ReadStructure`].
     elements: Vec<ReadSegment>,
@@ -370,5 +371,14 @@ mod test {
         test_read_structure_index_10: ("10T10B10B10S10M", 2, "10B", 20),
         test_read_structure_index_11: ("10T10B10B10S10M", 3, "10S", 30),
         test_read_structure_index_12: ("10T10B10B10S10M", 4, "10M", 40),
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn test_serde() {
+        let rs = ReadStructure::from_str("10T10B10B10S10M").unwrap();
+        let rs_json = serde_json::to_string(&rs).unwrap();
+        let rs2 = serde_json::from_str(&rs_json).unwrap();
+        assert_eq!(rs, rs2);
     }
 }

--- a/src/segment_type.rs
+++ b/src/segment_type.rs
@@ -13,6 +13,7 @@ use crate::ReadStructureError;
 /// The `SegmentType` type. See [the module level documentation](self) for more.
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, EnumIter, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(u8)]
 pub enum SegmentType {
     /// Template: the bases in the segment are reads of template (e.g. genomic dna, rna, etc.)


### PR DESCRIPTION
I have a use-case for read structures that involves serializing to/deserializing from JSON. This PR adds an optional `serde`  dependency and derives `serde::Serialize` and `serde::Deserialize` for all types, dependent on that feature.

`rustfmt` reorganizes the stuff in Cargo.toml to be in alphabetical order. I can roll this back if you don't want it.