### PR TITLE
fix: update Rust toolchain and modernize CI

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -11,52 +11,40 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
-          profile: minimal
-          toolchain: stable
-          override: false
+          toolchain: 1.75.0
 
       - name: Cache dependencies
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Run cargo check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
+        run: cargo check
 
   lints:
     name: Lints
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
-          profile: minimal
-          toolchain: stable
-          override: false
+          toolchain: 1.75.0
           components: rustfmt, clippy
 
       - name: Cache dependencies
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Run cargo fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all -- --check
 
       - name: Run cargo clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: -- -D warnings
+        run: cargo clippy --all-features -- -D warnings
 
   test:
     name: Test Suite
@@ -66,17 +54,15 @@ jobs:
         os: [ubuntu-latest]
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
-          profile: minimal
-          toolchain: stable
-          override: false
+          toolchain: 1.75.0
 
       - name: Cache dependencies
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Run tests
-        run: cargo test --verbose
+        run: cargo test --verbose --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,11 @@ repository = "https://github.com/fulcrumgenomics/read-structure"
 version = "0.2.1-rc.1"
 
 [dependencies]
-bstr = "0.2.17"
-serde = { version = "1.0.163", features = ["derive"], optional = true } 
-strum = "0.24"
-strum_macros = "0.24"
-thiserror = "1.0.30"
+bstr = "1.12"
+serde = { version = "1.0", features = ["derive"], optional = true }
+strum = "0.26"
+strum_macros = "0.26"
+thiserror = "1.0"
 
 [dev-dependencies]
-serde_json = "1.0.96"
+serde_json = "1.0"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.56.1"
+channel = "1.75.0"
 components = ["rustfmt", "clippy"]

--- a/src/read_structure.rs
+++ b/src/read_structure.rs
@@ -195,10 +195,10 @@ impl std::str::FromStr for ReadStructure {
             let length = if chars[i] as u8 == ANY_LENGTH_BYTE {
                 i += 1;
                 None
-            } else if chars[i].is_digit(10) {
+            } else if chars[i].is_ascii_digit() {
                 let mut len: usize = 0;
-                while i < chars.len() && chars[i].is_digit(10) {
-                    // Unwrap is save since we've checked `is_digit` already
+                while i < chars.len() && chars[i].is_ascii_digit() {
+                    // Unwrap is safe since we've checked `is_ascii_digit` already
                     let digit = chars[i].to_digit(10).unwrap() as usize;
                     len = (len * 10) + digit;
                     i += 1;


### PR DESCRIPTION
## Summary

CI on `main` is broken because `rust-toolchain.toml` pins Rust 1.56.1, but transitive dependencies (`proc-macro2`, `quote`) now require Rust 1.68+/1.71+.

- Bump Rust toolchain from 1.56.1 to 1.75.0 and update dependencies (`bstr` 0.2→1.12, `strum`/`strum_macros` 0.24→0.26)
- Replace deprecated `actions-rs` GitHub Actions with `dtolnay/rust-toolchain`, upgrade `actions/checkout` to v4 and `Swatinem/rust-cache` to v2
- Fix `is_digit(10)` → `is_ascii_digit()` clippy lint surfaced by the newer toolchain

## Test plan

- [ ] CI passes (Check, Lints, Test Suite)