### PR TITLE
feat: allow non-terminal `+` and re-structure where extraction happens

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,9 @@
 [package]
-authors = ["Nils Homer <nils@fulcrumgenomics.com>", "Seth Stadick <seth@fulcrumgenomics.com>"]
+authors = [
+    "Nils Homer <nils@fulcrumgenomics.com>",
+    "Seth Stadick <seth@fulcrumgenomics.com>",
+    "Tim Fennell <tim@fulcrumgenomics.com>"
+]
 categories = ["science"]
 description = "Library for parsing and working with read structure descriptions"
 documentation = "https://docs.rs/read-structure"
@@ -12,6 +16,14 @@ readme = "README.md"
 repository = "https://github.com/fulcrumgenomics/read-structure"
 rust-version = "1.85"
 version = "0.3.0"
+
+[features]
+# When enabled, the single indefinite-length (`+`) segment is permitted to appear
+# in any position in a read structure, not just the terminal position. The
+# "at most one `+` per structure" constraint still applies. When `+` is
+# non-terminal, attempting to extract bases for that segment or any segments
+# following it returns `ReadStructureError::SegmentNotExtractable`.
+non-terminal-plus = []
 
 [dependencies]
 bstr = "1.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,16 +17,7 @@ repository = "https://github.com/fulcrumgenomics/read-structure"
 rust-version = "1.85"
 version = "0.3.0"
 
-[features]
-# When enabled, the single indefinite-length (`+`) segment is permitted to appear
-# in any position in a read structure, not just the terminal position. The
-# "at most one `+` per structure" constraint still applies. When `+` is
-# non-terminal, attempting to extract bases for that segment or any segments
-# following it returns `ReadStructureError::SegmentNotExtractable`.
-non-terminal-plus = []
-
 [dependencies]
-bstr = "1.12"
 serde = { version = "1.0", features = ["derive"], optional = true }
 strum = "0.28"
 strum_macros = "0.28"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,14 +22,14 @@
 //!
 //! ```rust
 //! use std::str::FromStr;
-//! use read_structure::{ReadStructure, SegmentType};
+//! use read_structure::{ReadStructure, SegmentType, SkipHandling};
 //!
 //! let bases = b"\
 //!     AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGGGGGGGGCCCCCCCCTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT";
 //! let quals = &[b'I'; 168][..];
 //! let rs = ReadStructure::from_str("76T8B8B76T").unwrap();
 //!
-//! let templates: Vec<&[u8]> = rs.extract(bases, quals, /* include_skips */ true)
+//! let templates: Vec<&[u8]> = rs.extract(bases, quals, SkipHandling::Exclude)
 //!     .unwrap()
 //!     .filter(|(seg, _, _)| seg.kind == SegmentType::Template)
 //!     .map(|(_, bases, _)| bases)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,25 +21,23 @@
 //! Extracting segments from an actual read based on the read structure:
 //!
 //! ```rust
-//! use std::convert::TryFrom;
 //! use std::str::FromStr;
-//! use read_structure::{
-//!     ReadStructure,
-//!     SegmentType,
-//! };
-//! let read_sequence = b"\
-//!     AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGGGGGGGGCCCCCCCCTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT"
-//! .to_vec();
-//! let kind_of_interest = SegmentType::Template;
+//! use read_structure::{ReadStructure, SegmentType};
+//!
+//! let bases = b"\
+//!     AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGGGGGGGGCCCCCCCCTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT";
+//! let quals = &[b'I'; 168][..];
 //! let rs = ReadStructure::from_str("76T8B8B76T").unwrap();
 //!
-//! let mut sections = vec![];
-//! for segment in rs.segments_by_type(kind_of_interest) {
-//!     sections.push(segment.extract_bases(read_sequence.as_slice()).unwrap())
-//! }
-//! assert_eq!(sections, vec![
-//!     b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-//!     b"TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT"
+//! let templates: Vec<&[u8]> = rs.extract(bases, quals, /* include_skips */ true)
+//!     .unwrap()
+//!     .filter(|(seg, _, _)| seg.kind == SegmentType::Template)
+//!     .map(|(_, bases, _)| bases)
+//!     .collect();
+//!
+//! assert_eq!(templates, vec![
+//!     &b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"[..],
+//!     &b"TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT"[..],
 //! ]);
 //! ```
 
@@ -81,26 +79,14 @@ pub enum ReadStructureError {
     #[error("Read structure contains a non-terminal segment that has an indefinite length: {0}")]
     ReadStructureNonTerminalIndefiniteLengthReadSegment(ReadSegment),
 
-    #[error("Read ends before start of segment: {0}")]
-    ReadEndsBeforeSegment(ReadSegment),
-
-    #[error("Read ends before end of segment: {0}")]
-    ReadEndsAfterSegment(ReadSegment),
+    /// The read is too short to accommodate every fixed-length segment in the read
+    /// structure. `required` is the sum of all fixed segment lengths, plus 1 if the
+    /// structure also has an indefinite (`+`) segment (which must be at least one base).
+    #[error("Read of length {read_len} is shorter than required minimum {required}")]
+    ReadTooShort { read_len: usize, required: usize },
 
     #[error("ReadSegment too short: {0}")]
     ReadSegmentTooShort(String),
-
-    /// Returned when attempting to extract bases for a segment whose bases cannot be
-    /// determined from the read sequence alone. Only produced when the
-    /// `non-terminal-plus` feature is enabled and the indefinite-length (`+`) segment
-    /// appears in a non-terminal position: that segment and every segment after it
-    /// cannot be extracted without knowing the read length at extract time, which is
-    /// intentionally not supported.
-    #[cfg(feature = "non-terminal-plus")]
-    #[error(
-        "Segment bases cannot be extracted; the indefinite-length segment is not the last segment: {0}"
-    )]
-    SegmentNotExtractable(ReadSegment),
 
     #[error("ReadSegment str contained more than one segment: {0}")]
     ReadSegmentMultipleSegments(String),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,6 +90,18 @@ pub enum ReadStructureError {
     #[error("ReadSegment too short: {0}")]
     ReadSegmentTooShort(String),
 
+    /// Returned when attempting to extract bases for a segment whose bases cannot be
+    /// determined from the read sequence alone. Only produced when the
+    /// `non-terminal-plus` feature is enabled and the indefinite-length (`+`) segment
+    /// appears in a non-terminal position: that segment and every segment after it
+    /// cannot be extracted without knowing the read length at extract time, which is
+    /// intentionally not supported.
+    #[cfg(feature = "non-terminal-plus")]
+    #[error(
+        "Segment bases cannot be extracted; the indefinite-length segment is not the last segment: {0}"
+    )]
+    SegmentNotExtractable(ReadSegment),
+
     #[error("ReadSegment str contained more than one segment: {0}")]
     ReadSegmentMultipleSegments(String),
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,14 +76,20 @@ pub enum ReadStructureError {
     #[error("Read structure contains zero elements")]
     ReadStructureContainsZeroElements,
 
-    #[error("Read structure contains a non-terminal segment that has an indefinite length: {0}")]
-    ReadStructureNonTerminalIndefiniteLengthReadSegment(ReadSegment),
+    #[error("Read structure contains more than one indefinite-length (`+`) segment: {0}")]
+    ReadStructureMultipleIndefiniteLengthSegments(ReadSegment),
 
     /// The read is too short to accommodate every fixed-length segment in the read
     /// structure. `required` is the sum of all fixed segment lengths, plus 1 if the
     /// structure also has an indefinite (`+`) segment (which must be at least one base).
     #[error("Read of length {read_len} is shorter than required minimum {required}")]
     ReadTooShort { read_len: usize, required: usize },
+
+    /// A fixed-length read structure was handed a read of the wrong length. Fixed
+    /// structures require exact-length reads; anything longer is almost always a
+    /// caller bug (wrong structure for this data, or a stray adapter still attached).
+    #[error("Read of length {read_len} does not match fixed structure length {expected}")]
+    ReadTooLong { read_len: usize, expected: usize },
 
     #[error("ReadSegment too short: {0}")]
     ReadSegmentTooShort(String),

--- a/src/read_segment.rs
+++ b/src/read_segment.rs
@@ -29,6 +29,12 @@ pub struct ReadSegment {
     pub length: Option<usize>,
     /// The segment type
     pub kind: SegmentType,
+    /// Whether bases can be extracted for this segment given only the read sequence.
+    /// False for the indefinite-length segment and any segments following it when the
+    /// indefinite-length segment is non-terminal; always true otherwise. Only present
+    /// when the `non-terminal-plus` feature is enabled.
+    #[cfg(feature = "non-terminal-plus")]
+    pub(crate) extractable: bool,
 }
 
 impl ReadSegment {
@@ -80,6 +86,10 @@ impl ReadSegment {
     /// Errors if the read ends before the segment starts.
     #[inline]
     fn calculate_end<T>(&self, bases: &[T]) -> Result<usize, ReadStructureError> {
+        #[cfg(feature = "non-terminal-plus")]
+        if !self.extractable {
+            return Err(ReadStructureError::SegmentNotExtractable(*self));
+        }
         if bases.len() < self.offset {
             return Err(ReadStructureError::ReadEndsBeforeSegment(*self));
         }
@@ -101,7 +111,13 @@ impl ReadSegment {
         if option_new_length == self.length {
             *self
         } else {
-            Self { offset: self.offset, length: option_new_length, kind: self.kind }
+            Self {
+                offset: self.offset,
+                length: option_new_length,
+                kind: self.kind,
+                #[cfg(feature = "non-terminal-plus")]
+                extractable: self.extractable,
+            }
         }
     }
 }
@@ -149,43 +165,53 @@ mod test {
     use std::str::FromStr;
     use strum::IntoEnumIterator;
 
+    /// Helper to construct a `ReadSegment` in tests; handles the feature-gated
+    /// `extractable` field so tests compile in both configurations.
+    fn seg(offset: usize, length: Option<usize>, kind: SegmentType) -> ReadSegment {
+        ReadSegment {
+            offset,
+            length,
+            kind,
+            #[cfg(feature = "non-terminal-plus")]
+            extractable: true,
+        }
+    }
+
     #[test]
     fn test_read_segment_length() {
-        let seg_fixed_length =
-            ReadSegment { offset: 0, length: Some(10), kind: SegmentType::Template };
+        let seg_fixed_length = seg(0, Some(10), SegmentType::Template);
         assert_eq!(seg_fixed_length.length().unwrap(), 10);
         assert!(seg_fixed_length.has_length());
         assert_eq!(seg_fixed_length.length().unwrap(), 10);
-        let seg_no_length = ReadSegment { offset: 0, length: None, kind: SegmentType::Template };
+        let seg_no_length = seg(0, None, SegmentType::Template);
         assert!(!seg_no_length.has_length());
     }
 
     #[test]
     #[should_panic]
     fn test_read_segment_fixed_length_panic() {
-        let seg_no_length = ReadSegment { offset: 0, length: None, kind: SegmentType::Template };
+        let seg_no_length = seg(0, None, SegmentType::Template);
         seg_no_length.length().unwrap();
     }
 
     #[test]
     fn test_read_segment_to_string() {
         for tpe in SegmentType::iter() {
-            let seg_fixed_length = ReadSegment { offset: 0, length: Some(10), kind: tpe };
+            let seg_fixed_length = seg(0, Some(10), tpe);
             assert_eq!(seg_fixed_length.to_string(), format!("10{}", tpe.value()));
-            let seg_no_length = ReadSegment { offset: 0, length: None, kind: tpe };
+            let seg_no_length = seg(0, None, tpe);
             assert_eq!(seg_no_length.to_string(), format!("{}{}", ANY_LENGTH_STR, tpe.value()));
         }
     }
 
     #[test]
     fn test_read_segment_clone_with_new_end() {
-        let seg_fixed_length =
-            ReadSegment { offset: 2, length: Some(10), kind: SegmentType::Template };
+        let seg_fixed_length = seg(2, Some(10), SegmentType::Template);
         assert_eq!(seg_fixed_length.clone_with_new_end(10).length().unwrap(), 8);
         assert_eq!(seg_fixed_length.clone_with_new_end(8).length().unwrap(), 6);
         assert_eq!(seg_fixed_length.clone_with_new_end(2).length(), None);
         assert_eq!(seg_fixed_length.clone_with_new_end(1).length(), None);
-        let seg_no_length = ReadSegment { offset: 2, length: None, kind: SegmentType::Template };
+        let seg_no_length = seg(2, None, SegmentType::Template);
         assert_eq!(seg_no_length.clone_with_new_end(10).length().unwrap(), 8);
         assert_eq!(seg_no_length.clone_with_new_end(8).length().unwrap(), 6);
         assert_eq!(seg_no_length.clone_with_new_end(2).length(), None);
@@ -194,27 +220,21 @@ mod test {
 
     #[test]
     fn test_extract_bases() {
-        let seg = ReadSegment { offset: 2, length: Some(3), kind: SegmentType::MolecularBarcode };
-        assert_eq!(seg.extract_bases(B("GATTACA")).unwrap(), b"TTA");
+        let s = seg(2, Some(3), SegmentType::MolecularBarcode);
+        assert_eq!(s.extract_bases(B("GATTACA")).unwrap(), b"TTA");
     }
 
     #[test]
     fn test_extract_bases_and_quals() {
-        let seg = ReadSegment { offset: 2, length: Some(3), kind: SegmentType::MolecularBarcode };
-        let sub = seg.extract_bases_and_quals(B("GATTACA"), B("1234567")).unwrap();
+        let s = seg(2, Some(3), SegmentType::MolecularBarcode);
+        let sub = s.extract_bases_and_quals(B("GATTACA"), B("1234567")).unwrap();
         assert_eq!(sub.0, B("TTA"));
         assert_eq!(sub.1, B("345"));
     }
 
     #[test]
     fn test_read_segment_from_str() {
-        assert_eq!(
-            ReadSegment::from_str("+T").unwrap(),
-            ReadSegment { offset: 0, length: None, kind: SegmentType::Template }
-        );
-        assert_eq!(
-            ReadSegment::from_str("10S").unwrap(),
-            ReadSegment { offset: 0, length: Some(10), kind: SegmentType::Skip }
-        );
+        assert_eq!(ReadSegment::from_str("+T").unwrap(), seg(0, None, SegmentType::Template));
+        assert_eq!(ReadSegment::from_str("10S").unwrap(), seg(0, Some(10), SegmentType::Skip));
     }
 }

--- a/src/read_segment.rs
+++ b/src/read_segment.rs
@@ -5,8 +5,6 @@
 //! length must be `Some(usize)`, or an indefinite length (can be any length, 1 or more)
 //! in which case length must be `None`.
 
-use std::{convert::TryFrom, io::Read};
-
 use crate::{ReadStructure, ReadStructureError, segment_type::SegmentType};
 
 /// A character that can be put in place of a number in a read structure to mean "1 or more bases".
@@ -18,107 +16,31 @@ pub const ANY_LENGTH_BYTE_SLICE: &[u8] = b"+";
 /// A string that can be put in place of a number in a read structure to mean "1 or more bases".
 pub const ANY_LENGTH_STR: &str = "+";
 
-/// The read segment describing a given kind ([`SegmentType`]), optional length, and offset of the
-/// bases within a [`crate::read_structure::ReadStructure`].
-#[derive(Debug, Copy, Clone, PartialEq)]
+/// A single segment of a read structure: a segment type and an optional fixed length.
+///
+/// Segments are typically obtained by parsing a [`ReadStructure`]; the positions of the
+/// segment's bases within a read are tracked by the enclosing [`ReadStructure`], not
+/// here.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ReadSegment {
-    /// The offset in the read if the segment belongs to a read structure
-    pub(crate) offset: usize,
-    /// The optional length of this segment
+    /// The optional length of this segment. `None` means "the rest of the read" — the
+    /// indefinite-length (`+`) segment. At most one segment per read structure may be
+    /// indefinite.
     pub length: Option<usize>,
-    /// The segment type
+    /// The segment type.
     pub kind: SegmentType,
-    /// Whether bases can be extracted for this segment given only the read sequence.
-    /// False for the indefinite-length segment and any segments following it when the
-    /// indefinite-length segment is non-terminal; always true otherwise. Only present
-    /// when the `non-terminal-plus` feature is enabled.
-    #[cfg(feature = "non-terminal-plus")]
-    pub(crate) extractable: bool,
 }
 
 impl ReadSegment {
-    /// Extract the bases corresponding to this [`ReadSegment`] from a slice.
-    ///
-    /// # Errors
-    ///
-    /// - If the segment does not fall wholely within the slice.
-    pub fn extract_bases<'a, B>(&self, bases: &'a [B]) -> Result<&'a [B], ReadStructureError> {
-        let end = self.calculate_end(bases)?;
-        Ok(&bases[self.offset..end])
-    }
-
-    /// Extract the bases and corresponding quals to this [`ReadSegment`] from a slice.
-    ///
-    /// # Errors
-    ///
-    /// - If the segment does not fall wholely within the slice.
-    /// - If the bases and quals lengths are not equal.
-    pub fn extract_bases_and_quals<'a, B, Q>(
-        &self,
-        bases: &'a [B],
-        quals: &'a [Q],
-    ) -> Result<(&'a [B], &'a [Q]), ReadStructureError> {
-        if bases.len() != quals.len() {
-            return Err(ReadStructureError::MismatchingBasesAndQualsLen {
-                bases_len: bases.len(),
-                quals_len: quals.len(),
-            });
-        }
-        let end = self.calculate_end(bases)?;
-        Ok((&bases[self.offset..end], &quals[self.offset..end]))
-    }
-
-    /// Returns the length of the read segment.
+    /// Returns the length of the read segment, or `None` for an indefinite-length (`+`) segment.
     pub fn length(&self) -> Option<usize> {
         self.length
     }
 
-    /// Returns true if the read segment has a length defined (i.e. not `None`)
+    /// Returns true if the read segment has a defined length (i.e. is not `+`).
     pub fn has_length(&self) -> bool {
         self.length.is_some()
-    }
-
-    /// Returns the end position for the segment for the given read.
-    ///
-    /// # Errors
-    ///
-    /// Errors if the read ends before the segment starts.
-    #[inline]
-    fn calculate_end<T>(&self, bases: &[T]) -> Result<usize, ReadStructureError> {
-        #[cfg(feature = "non-terminal-plus")]
-        if !self.extractable {
-            return Err(ReadStructureError::SegmentNotExtractable(*self));
-        }
-        if bases.len() < self.offset {
-            return Err(ReadStructureError::ReadEndsBeforeSegment(*self));
-        }
-        if let Some(l) = self.length {
-            if bases.len() < self.offset + l {
-                return Err(ReadStructureError::ReadEndsAfterSegment(*self));
-            }
-            Ok(self.offset + l)
-        } else {
-            Ok(bases.len())
-        }
-    }
-
-    /// Clone the read segment but with an updated end. If the new end is before
-    /// the current offset, the read segment will have no length defined.
-    /// Otherwise, the new length will be reduced based on the offset (`end - offset`).
-    fn clone_with_new_end(&self, end: usize) -> Self {
-        let option_new_length = if self.offset >= end { None } else { Some(end - self.offset) };
-        if option_new_length == self.length {
-            *self
-        } else {
-            Self {
-                offset: self.offset,
-                length: option_new_length,
-                kind: self.kind,
-                #[cfg(feature = "non-terminal-plus")]
-                extractable: self.extractable,
-            }
-        }
     }
 }
 
@@ -157,84 +79,47 @@ impl std::fmt::Display for ReadSegment {
 
 #[cfg(test)]
 mod test {
+    use crate::read_segment::ANY_LENGTH_STR;
     use crate::read_segment::ReadSegment;
-    use crate::read_segment::{ANY_LENGTH_BYTE, ANY_LENGTH_STR};
     use crate::segment_type::SegmentType;
-    use bstr::B;
-    use std::convert::TryFrom;
     use std::str::FromStr;
     use strum::IntoEnumIterator;
 
-    /// Helper to construct a `ReadSegment` in tests; handles the feature-gated
-    /// `extractable` field so tests compile in both configurations.
-    fn seg(offset: usize, length: Option<usize>, kind: SegmentType) -> ReadSegment {
-        ReadSegment {
-            offset,
-            length,
-            kind,
-            #[cfg(feature = "non-terminal-plus")]
-            extractable: true,
-        }
-    }
-
     #[test]
     fn test_read_segment_length() {
-        let seg_fixed_length = seg(0, Some(10), SegmentType::Template);
+        let seg_fixed_length = ReadSegment { length: Some(10), kind: SegmentType::Template };
         assert_eq!(seg_fixed_length.length().unwrap(), 10);
         assert!(seg_fixed_length.has_length());
-        assert_eq!(seg_fixed_length.length().unwrap(), 10);
-        let seg_no_length = seg(0, None, SegmentType::Template);
+        let seg_no_length = ReadSegment { length: None, kind: SegmentType::Template };
         assert!(!seg_no_length.has_length());
     }
 
     #[test]
     #[should_panic]
     fn test_read_segment_fixed_length_panic() {
-        let seg_no_length = seg(0, None, SegmentType::Template);
+        let seg_no_length = ReadSegment { length: None, kind: SegmentType::Template };
         seg_no_length.length().unwrap();
     }
 
     #[test]
     fn test_read_segment_to_string() {
         for tpe in SegmentType::iter() {
-            let seg_fixed_length = seg(0, Some(10), tpe);
+            let seg_fixed_length = ReadSegment { length: Some(10), kind: tpe };
             assert_eq!(seg_fixed_length.to_string(), format!("10{}", tpe.value()));
-            let seg_no_length = seg(0, None, tpe);
+            let seg_no_length = ReadSegment { length: None, kind: tpe };
             assert_eq!(seg_no_length.to_string(), format!("{}{}", ANY_LENGTH_STR, tpe.value()));
         }
     }
 
     #[test]
-    fn test_read_segment_clone_with_new_end() {
-        let seg_fixed_length = seg(2, Some(10), SegmentType::Template);
-        assert_eq!(seg_fixed_length.clone_with_new_end(10).length().unwrap(), 8);
-        assert_eq!(seg_fixed_length.clone_with_new_end(8).length().unwrap(), 6);
-        assert_eq!(seg_fixed_length.clone_with_new_end(2).length(), None);
-        assert_eq!(seg_fixed_length.clone_with_new_end(1).length(), None);
-        let seg_no_length = seg(2, None, SegmentType::Template);
-        assert_eq!(seg_no_length.clone_with_new_end(10).length().unwrap(), 8);
-        assert_eq!(seg_no_length.clone_with_new_end(8).length().unwrap(), 6);
-        assert_eq!(seg_no_length.clone_with_new_end(2).length(), None);
-        assert_eq!(seg_no_length.clone_with_new_end(1).length(), None);
-    }
-
-    #[test]
-    fn test_extract_bases() {
-        let s = seg(2, Some(3), SegmentType::MolecularBarcode);
-        assert_eq!(s.extract_bases(B("GATTACA")).unwrap(), b"TTA");
-    }
-
-    #[test]
-    fn test_extract_bases_and_quals() {
-        let s = seg(2, Some(3), SegmentType::MolecularBarcode);
-        let sub = s.extract_bases_and_quals(B("GATTACA"), B("1234567")).unwrap();
-        assert_eq!(sub.0, B("TTA"));
-        assert_eq!(sub.1, B("345"));
-    }
-
-    #[test]
     fn test_read_segment_from_str() {
-        assert_eq!(ReadSegment::from_str("+T").unwrap(), seg(0, None, SegmentType::Template));
-        assert_eq!(ReadSegment::from_str("10S").unwrap(), seg(0, Some(10), SegmentType::Skip));
+        assert_eq!(
+            ReadSegment::from_str("+T").unwrap(),
+            ReadSegment { length: None, kind: SegmentType::Template }
+        );
+        assert_eq!(
+            ReadSegment::from_str("10S").unwrap(),
+            ReadSegment { length: Some(10), kind: SegmentType::Skip }
+        );
     }
 }

--- a/src/read_segment.rs
+++ b/src/read_segment.rs
@@ -23,9 +23,12 @@ pub const ANY_LENGTH_STR: &str = "+";
 /// here.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct ReadSegment {
-    /// The optional length of this segment. `None` means "the rest of the read" — the
-    /// indefinite-length (`+`) segment. At most one segment per read structure may be
-    /// indefinite.
+    /// The optional length of this segment. `None` means this is the indefinite-length
+    /// (`+`) segment; its concrete span is resolved by the enclosing [`ReadStructure`]
+    /// at extract time (it runs from just after the preceding segments up to just
+    /// before the following segments, so in `8B+M10T` the `+M` segment covers
+    /// everything between byte 8 and `read_len - 10`). At most one segment per read
+    /// structure may be indefinite.
     pub length: Option<usize>,
     /// The segment type.
     pub kind: SegmentType,

--- a/src/read_segment.rs
+++ b/src/read_segment.rs
@@ -22,7 +22,6 @@ pub const ANY_LENGTH_STR: &str = "+";
 /// segment's bases within a read are tracked by the enclosing [`ReadStructure`], not
 /// here.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ReadSegment {
     /// The optional length of this segment. `None` means "the rest of the read" — the
     /// indefinite-length (`+`) segment. At most one segment per read structure may be

--- a/src/read_structure.rs
+++ b/src/read_structure.rs
@@ -87,7 +87,7 @@ impl ReadStructure {
         }
 
         if num_indefinite > 1 {
-            return Err(ReadStructureError::ReadStructureNonTerminalIndefiniteLengthReadSegment(
+            return Err(ReadStructureError::ReadStructureMultipleIndefiniteLengthSegments(
                 *segments.iter().find(|s| !s.has_length()).unwrap(),
             ));
         }
@@ -146,6 +146,10 @@ impl ReadStructure {
     ///   segment. When the structure also has a `+` segment, the read must be strictly
     ///   longer than the sum of the fixed-segment lengths (since `+` means at least
     ///   one base).
+    /// - [`ReadStructureError::ReadTooLong`] if the structure has no `+` segment and
+    ///   `bases.len()` does not exactly match `length_of_fixed_segments`. Silently
+    ///   truncating trailing bases is almost always a bug (wrong structure, stray
+    ///   adapter, etc.), so we require an exact match.
     pub fn extract<'rs, 'b>(
         &'rs self,
         bases: &'b [u8],
@@ -166,6 +170,12 @@ impl ReadStructure {
         };
         if bases.len() < required {
             return Err(ReadStructureError::ReadTooShort { read_len: bases.len(), required });
+        }
+        if self.plus_index.is_none() && bases.len() > self.length_of_fixed_segments {
+            return Err(ReadStructureError::ReadTooLong {
+                read_len: bases.len(),
+                expected: self.length_of_fixed_segments,
+            });
         }
 
         Ok(ExtractedSegments {
@@ -737,6 +747,35 @@ mod test {
             }
             other => panic!("expected ReadTooShort, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn test_extract_errors_when_read_too_long_for_fixed() {
+        // Fixed structures must get an exact-length read. Trailing bases are almost
+        // always a bug (wrong structure, stray adapter), not data to quietly drop.
+        let rs = ReadStructure::from_str("10T8B").unwrap();
+        let bases = vec![b'X'; 20]; // fixed length is 18
+        let quals = vec![b'#'; 20];
+        let err = rs.extract(&bases, &quals, SkipHandling::Include).unwrap_err();
+        match err {
+            ReadStructureError::ReadTooLong { read_len, expected } => {
+                assert_eq!(read_len, 20);
+                assert_eq!(expected, 18);
+            }
+            other => panic!("expected ReadTooLong, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_extract_allows_extra_bases_when_plus_present() {
+        // With a `+`, extra bases are by definition absorbed by the `+` segment.
+        let rs = ReadStructure::from_str("8B+M10T").unwrap();
+        let bases = b"BBBBBBBBUUUUUUUUUUUUUUUUUUUUUUUUTTTTTTTTTT";
+        let quals = b"!!!!!!!!@@@@@@@@@@@@@@@@@@@@@@@@##########";
+        assert_eq!(bases.len(), 42);
+        let out: Vec<_> = rs.extract(bases, quals, SkipHandling::Include).unwrap().collect();
+        assert_eq!(out.len(), 3);
+        assert_eq!(out[1].1.len(), 24); // 42 - 8 - 10
     }
 
     #[test]

--- a/src/read_structure.rs
+++ b/src/read_structure.rs
@@ -29,10 +29,20 @@ pub struct ReadStructure {
 impl ReadStructure {
     /// Builds a new [`ReadStructure`] from a vector of [`ReadSegment`]s.
     ///
+    /// At most one segment may have an indefinite length. By default that segment must
+    /// be the last one. When the `non-terminal-plus` feature is enabled, the
+    /// indefinite-length segment is also permitted in a non-terminal position; in that
+    /// case the indefinite segment and every segment following it will have their
+    /// `extractable` flag set to `false`, and calling [`ReadSegment::extract_bases`] or
+    /// [`ReadSegment::extract_bases_and_quals`] on them returns
+    /// [`ReadStructureError::SegmentNotExtractable`].
+    ///
     /// # Errors
     ///
-    /// Returns `Err` if the any segment but the last has an indefinite length, or no elements
-    /// exist.
+    /// - Returns `Err` if no elements exist.
+    /// - Returns `Err` if more than one segment has an indefinite length.
+    /// - Without the `non-terminal-plus` feature, returns `Err` if the single
+    ///   indefinite-length segment is not the last segment.
     #[allow(clippy::missing_panics_doc)]
     pub fn new(mut segments: Vec<ReadSegment>) -> Result<Self, ReadStructureError> {
         if segments.is_empty() {
@@ -41,26 +51,33 @@ impl ReadStructure {
 
         let mut num_indefinite = 0;
         let mut length_of_fixed_segments = 0;
-        for s in &segments {
+        let mut indefinite_index: Option<usize> = None;
+        for (i, s) in segments.iter().enumerate() {
             if let Some(len) = s.length {
                 length_of_fixed_segments += len;
             } else {
                 num_indefinite += 1;
+                if indefinite_index.is_none() {
+                    indefinite_index = Some(i);
+                }
             }
         }
 
-        if segments.last().unwrap().has_length() {
-            if num_indefinite != 0 {
-                return Err(
-                    ReadStructureError::ReadStructureNonTerminalIndefiniteLengthReadSegment(
-                        *segments.iter().find(|s| !s.has_length()).unwrap(),
-                    ),
-                );
-            }
-        } else if num_indefinite > 1 {
+        if num_indefinite > 1 {
             return Err(ReadStructureError::ReadStructureNonTerminalIndefiniteLengthReadSegment(
                 *segments.iter().find(|s| !s.has_length()).unwrap(),
             ));
+        }
+
+        #[cfg(not(feature = "non-terminal-plus"))]
+        if let Some(idx) = indefinite_index {
+            if idx != segments.len() - 1 {
+                return Err(
+                    ReadStructureError::ReadStructureNonTerminalIndefiniteLengthReadSegment(
+                        segments[idx],
+                    ),
+                );
+            }
         }
 
         let mut off: usize = 0;
@@ -68,13 +85,23 @@ impl ReadStructure {
             segment.offset = off;
             off += segment.length.unwrap_or(0);
         }
+
+        #[cfg(feature = "non-terminal-plus")]
+        if let Some(idx) = indefinite_index {
+            if idx != segments.len() - 1 {
+                for segment in &mut segments[idx..] {
+                    segment.extractable = false;
+                }
+            }
+        }
+
         Ok(ReadStructure { elements: segments, length_of_fixed_segments })
     }
 
     /// Returns `true` if the [`ReadStructure`] has a fixed (i.e. non-variable) length,
-    /// `false` if there are segments but no fixed length.
+    /// `false` if any segment has an indefinite length.
     pub fn has_fixed_length(&self) -> bool {
-        self.elements.last().unwrap().has_length()
+        self.elements.iter().all(ReadSegment::has_length)
     }
 
     /// Returns the fixed length if there is one.
@@ -211,7 +238,13 @@ impl std::str::FromStr for ReadStructure {
                     )));
                 }
                 i += 1;
-                segs.push(ReadSegment { offset, length, kind });
+                segs.push(ReadSegment {
+                    offset,
+                    length,
+                    kind,
+                    #[cfg(feature = "non-terminal-plus")]
+                    extractable: true,
+                });
                 offset += length.unwrap_or(0);
             } else {
                 return Err(ReadStructureError::ReadStructureHadUnknownType(
@@ -276,7 +309,14 @@ mod test {
         test_read_structure_allow_any_char_only_once_and_for_last_segment_panic_1: "5M++T",
         test_read_structure_allow_any_char_only_once_and_for_last_segment_panic_2: "5M70+T",
         test_read_structure_allow_any_char_only_once_and_for_last_segment_panic_3: "+M+T",
-        test_read_structure_allow_any_char_only_once_and_for_last_segment_panic_4: "+M70T",
+    }
+
+    // With the `non-terminal-plus` feature enabled, this is a legal read structure.
+    // Tested for acceptance in the feature-gated test module below.
+    #[test]
+    #[cfg(not(feature = "non-terminal-plus"))]
+    fn test_read_structure_strict_rejects_non_terminal_plus() {
+        assert!(ReadStructure::from_str("+M70T").is_err());
     }
 
     macro_rules! test_read_structure_from_str_invalid {
@@ -378,5 +418,112 @@ mod test {
         let rs_json = serde_json::to_string(&rs).unwrap();
         let rs2 = serde_json::from_str(&rs_json).unwrap();
         assert_eq!(rs, rs2);
+    }
+
+    // ---- tests covering the `non-terminal-plus` feature ----
+
+    #[cfg(feature = "non-terminal-plus")]
+    mod non_terminal_plus {
+        use crate::ReadStructureError;
+        use crate::read_structure::ReadStructure;
+        use std::str::FromStr;
+
+        #[test]
+        fn test_accepts_middle_plus() {
+            let rs = ReadStructure::from_str("8B+M10T").unwrap();
+            assert_eq!(rs.to_string(), "8B+M10T");
+            assert_eq!(rs.number_of_segments(), 3);
+        }
+
+        #[test]
+        fn test_accepts_leading_plus() {
+            let rs = ReadStructure::from_str("+B10T").unwrap();
+            assert_eq!(rs.to_string(), "+B10T");
+            assert_eq!(rs.number_of_segments(), 2);
+        }
+
+        #[test]
+        fn test_accepts_trailing_plus() {
+            // Trailing `+` is still legal (it was before and it is now).
+            let rs = ReadStructure::from_str("10T+M").unwrap();
+            assert_eq!(rs.to_string(), "10T+M");
+        }
+
+        #[test]
+        fn test_accepts_middle_plus_between_fixed_runs() {
+            let rs = ReadStructure::from_str("10T8B+M10T").unwrap();
+            assert_eq!(rs.to_string(), "10T8B+M10T");
+            assert_eq!(rs.number_of_segments(), 4);
+        }
+
+        #[test]
+        fn test_rejects_two_consecutive_plus() {
+            assert!(ReadStructure::from_str("++M").is_err());
+        }
+
+        #[test]
+        fn test_rejects_two_separate_plus() {
+            assert!(ReadStructure::from_str("+M+T").is_err());
+        }
+
+        #[test]
+        fn test_rejects_two_plus_in_longer_structure() {
+            assert!(ReadStructure::from_str("5M+T+B").is_err());
+        }
+
+        #[test]
+        fn test_pre_plus_segments_still_extract() {
+            let rs = ReadStructure::from_str("8B+M10T").unwrap();
+            let read = b"BBBBBBBBUUUUUUUUUUUUTTTTTTTTTT";
+            assert_eq!(rs.segments()[0].extract_bases(read).unwrap(), b"BBBBBBBB");
+        }
+
+        #[test]
+        fn test_middle_plus_segment_not_extractable() {
+            let rs = ReadStructure::from_str("8B+M10T").unwrap();
+            let read = b"BBBBBBBBUUUUUUUUUUUUTTTTTTTTTT";
+            let err = rs.segments()[1].extract_bases(read).unwrap_err();
+            assert!(matches!(err, ReadStructureError::SegmentNotExtractable(_)));
+        }
+
+        #[test]
+        fn test_post_plus_segment_not_extractable() {
+            let rs = ReadStructure::from_str("8B+M10T").unwrap();
+            let read = b"BBBBBBBBUUUUUUUUUUUUTTTTTTTTTT";
+            let err = rs.segments()[2].extract_bases(read).unwrap_err();
+            assert!(matches!(err, ReadStructureError::SegmentNotExtractable(_)));
+        }
+
+        #[test]
+        fn test_extract_bases_and_quals_errors_on_post_plus() {
+            let rs = ReadStructure::from_str("8B+M10T").unwrap();
+            let bases = b"BBBBBBBBUUUUUUUUUUUUTTTTTTTTTT";
+            let quals = b"##########################????";
+            let err = rs.segments()[2].extract_bases_and_quals(bases, quals).unwrap_err();
+            assert!(matches!(err, ReadStructureError::SegmentNotExtractable(_)));
+        }
+
+        #[test]
+        fn test_trailing_plus_still_extractable() {
+            // Terminal `+` must remain extractable under the feature.
+            let rs = ReadStructure::from_str("10T+M").unwrap();
+            let read = b"AAAAAAAAAAGGGGGGGGGG";
+            assert_eq!(rs.segments()[1].extract_bases(read).unwrap(), b"GGGGGGGGGG");
+        }
+
+        #[test]
+        fn test_has_fixed_length_middle_plus() {
+            assert!(!ReadStructure::from_str("8B+M10T").unwrap().has_fixed_length());
+        }
+
+        #[test]
+        fn test_has_fixed_length_no_plus() {
+            assert!(ReadStructure::from_str("10T10B").unwrap().has_fixed_length());
+        }
+
+        #[test]
+        fn test_fixed_length_none_for_middle_plus() {
+            assert!(ReadStructure::from_str("8B+M10T").unwrap().fixed_length().is_none());
+        }
     }
 }

--- a/src/read_structure.rs
+++ b/src/read_structure.rs
@@ -12,7 +12,18 @@ use crate::ReadStructureError;
 use crate::read_segment::ANY_LENGTH_BYTE;
 use crate::read_segment::ReadSegment;
 use crate::segment_type::SegmentType;
+use std::iter::FusedIterator;
 use std::ops::Index;
+
+/// Controls whether [`SegmentType::Skip`] segments are emitted by
+/// [`ReadStructure::extract`].
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+pub enum SkipHandling {
+    /// Emit every segment, including those of type [`SegmentType::Skip`].
+    Include,
+    /// Skip over [`SegmentType::Skip`] segments in the output iterator.
+    Exclude,
+}
 
 /// A read structure made up of one or more [`ReadSegment`]s.
 ///
@@ -22,6 +33,7 @@ use std::ops::Index;
 /// segments.
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(into = "String", try_from = "String"))]
 pub struct ReadStructure {
     /// The elements that make up the [`ReadStructure`].
     elements: Vec<ReadSegment>,
@@ -124,8 +136,8 @@ impl ReadStructure {
     /// All error conditions are checked up front, so the returned iterator is infallible
     /// and can be cheaply `.collect()`ed into a `Vec` when an owned collection is needed.
     ///
-    /// When `include_skips` is `false`, segments of type [`SegmentType::Skip`] are
-    /// omitted from the output.
+    /// `skip_handling` controls whether [`SegmentType::Skip`] segments are emitted
+    /// ([`SkipHandling::Include`]) or silently dropped ([`SkipHandling::Exclude`]).
     ///
     /// # Errors
     ///
@@ -138,7 +150,7 @@ impl ReadStructure {
         &'rs self,
         bases: &'b [u8],
         quals: &'b [u8],
-        include_skips: bool,
+        skip_handling: SkipHandling,
     ) -> Result<ExtractedSegments<'rs, 'b>, ReadStructureError> {
         if bases.len() != quals.len() {
             return Err(ReadStructureError::MismatchingBasesAndQualsLen {
@@ -163,7 +175,7 @@ impl ReadStructure {
             post_plus_len: self.post_plus_len,
             bases,
             quals,
-            include_skips,
+            skip_handling,
             next_index: 0,
         })
     }
@@ -238,10 +250,10 @@ impl ReadStructure {
 /// Iterator returned by [`ReadStructure::extract`].
 ///
 /// Yields `(&ReadSegment, &[u8] bases, &[u8] quals)` triples — one per segment in
-/// the underlying read structure, in order (with `Skip` segments optionally filtered).
-/// The iterator is infallible: all error checks are performed up front in
-/// [`ReadStructure::extract`].
-#[derive(Debug)]
+/// the underlying read structure, in order (with `Skip` segments optionally filtered
+/// per [`SkipHandling`]). The iterator is infallible: all error checks are performed
+/// up front in [`ReadStructure::extract`].
+#[derive(Debug, Clone)]
 pub struct ExtractedSegments<'rs, 'b> {
     elements: &'rs [ReadSegment],
     offsets: &'rs [isize],
@@ -249,7 +261,7 @@ pub struct ExtractedSegments<'rs, 'b> {
     post_plus_len: usize,
     bases: &'b [u8],
     quals: &'b [u8],
-    include_skips: bool,
+    skip_handling: SkipHandling,
     next_index: usize,
 }
 
@@ -261,7 +273,7 @@ impl<'rs, 'b> Iterator for ExtractedSegments<'rs, 'b> {
             let i = self.next_index;
             self.next_index += 1;
             let seg = &self.elements[i];
-            if !self.include_skips && seg.kind == SegmentType::Skip {
+            if self.skip_handling == SkipHandling::Exclude && seg.kind == SegmentType::Skip {
                 continue;
             }
             let (start, end) = if Some(i) == self.plus_index {
@@ -281,6 +293,8 @@ impl<'rs, 'b> Iterator for ExtractedSegments<'rs, 'b> {
         None
     }
 }
+
+impl FusedIterator for ExtractedSegments<'_, '_> {}
 
 impl IntoIterator for ReadStructure {
     type Item = ReadSegment;
@@ -374,10 +388,25 @@ impl TryFrom<&[ReadSegment]> for ReadStructure {
     }
 }
 
+impl TryFrom<String> for ReadStructure {
+    type Error = ReadStructureError;
+    /// Parses a read structure from an owned string; equivalent to [`FromStr`].
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        s.parse()
+    }
+}
+
+impl From<ReadStructure> for String {
+    /// Renders the read structure to its canonical string form (e.g. `"8B+M10T"`).
+    fn from(rs: ReadStructure) -> Self {
+        rs.to_string()
+    }
+}
+
 #[cfg(test)]
 mod test {
     use crate::ReadStructureError;
-    use crate::read_structure::ReadStructure;
+    use crate::read_structure::{ReadStructure, SkipHandling};
     use crate::segment_type::SegmentType;
     use std::str::FromStr;
 
@@ -399,7 +428,7 @@ mod test {
     }
 
     #[test]
-    fn test_read_structure_allow_anylength_char_only_once_and_for_last_segment() {
+    fn test_read_structure_accepts_plus_at_any_position_once() {
         assert_eq!(ReadStructure::from_str("5M+T").unwrap().to_string(), "5M+T");
         assert_eq!(ReadStructure::from_str("+M").unwrap().to_string(), "+M");
     }
@@ -523,6 +552,34 @@ mod test {
         assert_eq!(rs, rs2);
     }
 
+    #[test]
+    #[cfg(feature = "serde")]
+    fn test_serde_middle_plus_round_trip() {
+        let rs = ReadStructure::from_str("8B+M10T").unwrap();
+        let rs_json = serde_json::to_string(&rs).unwrap();
+        let rs2: ReadStructure = serde_json::from_str(&rs_json).unwrap();
+        assert_eq!(rs, rs2);
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn test_serde_wire_format_is_canonical_string() {
+        // Pin the serialized form: a `ReadStructure` encodes as a single JSON
+        // string, not as an object with internal cached fields.
+        let rs = ReadStructure::from_str("8B+M10T").unwrap();
+        let rs_json = serde_json::to_string(&rs).unwrap();
+        assert_eq!(rs_json, "\"8B+M10T\"");
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn test_serde_rejects_invalid_string() {
+        let err = serde_json::from_str::<ReadStructure>("\"not a read structure\"").unwrap_err();
+        // Any deserialization error is acceptable here; just ensure it doesn't
+        // silently produce an inconsistent structure.
+        assert!(!err.to_string().is_empty());
+    }
+
     // ---- non-terminal `+` acceptance (parsing + round-trip) ----
 
     #[test]
@@ -571,7 +628,7 @@ mod test {
         let rs = ReadStructure::from_str("10T8B").unwrap();
         let bases = b"AAAAAAAAAAGGGGGGGG";
         let quals = b"IIIIIIIIIIJJJJJJJJ";
-        let out: Vec<_> = rs.extract(bases, quals, true).unwrap().collect();
+        let out: Vec<_> = rs.extract(bases, quals, SkipHandling::Include).unwrap().collect();
         assert_eq!(out.len(), 2);
         assert_eq!(out[0].0.kind, SegmentType::Template);
         assert_eq!(out[0].1, b"AAAAAAAAAA");
@@ -586,7 +643,7 @@ mod test {
         let rs = ReadStructure::from_str("10T+M").unwrap();
         let bases = b"AAAAAAAAAAGGGGGGGGGG";
         let quals = b"IIIIIIIIIIJJJJJJJJJJ";
-        let out: Vec<_> = rs.extract(bases, quals, true).unwrap().collect();
+        let out: Vec<_> = rs.extract(bases, quals, SkipHandling::Include).unwrap().collect();
         assert_eq!(out.len(), 2);
         assert_eq!(out[0].1, b"AAAAAAAAAA");
         assert_eq!(out[1].1, b"GGGGGGGGGG");
@@ -598,7 +655,7 @@ mod test {
         let rs = ReadStructure::from_str("+B10T").unwrap();
         let bases = b"BBBBBTTTTTTTTTT";
         let quals = b"!!!!!##########";
-        let out: Vec<_> = rs.extract(bases, quals, true).unwrap().collect();
+        let out: Vec<_> = rs.extract(bases, quals, SkipHandling::Include).unwrap().collect();
         assert_eq!(out.len(), 2);
         assert_eq!(out[0].0.kind, SegmentType::SampleBarcode);
         assert_eq!(out[0].1, b"BBBBB");
@@ -614,7 +671,7 @@ mod test {
         let bases = b"BBBBBBBBUUUUUUUUUUUUTTTTTTTTTT";
         let quals = b"!!!!!!!!@@@@@@@@@@@@##########";
         assert_eq!(bases.len(), 30);
-        let out: Vec<_> = rs.extract(bases, quals, true).unwrap().collect();
+        let out: Vec<_> = rs.extract(bases, quals, SkipHandling::Include).unwrap().collect();
         assert_eq!(out.len(), 3);
         assert_eq!(out[0].1, b"BBBBBBBB");
         assert_eq!(out[0].2, b"!!!!!!!!");
@@ -632,7 +689,7 @@ mod test {
         let bases = b"TTTTTTTTTTBBBBBBBBUUUUUUUUUUUUTTTTTTTTTT";
         let quals = b"IIIIIIIIII!!!!!!!!@@@@@@@@@@@@##########";
         assert_eq!(bases.len(), 40);
-        let out: Vec<_> = rs.extract(bases, quals, true).unwrap().collect();
+        let out: Vec<_> = rs.extract(bases, quals, SkipHandling::Include).unwrap().collect();
         assert_eq!(out.len(), 4);
         assert_eq!(out[0].1, b"TTTTTTTTTT");
         assert_eq!(out[1].1, b"BBBBBBBB");
@@ -645,7 +702,7 @@ mod test {
         let rs = ReadStructure::from_str("8S+M10T").unwrap();
         let bases = b"SSSSSSSSUUUUUUUUUUUUTTTTTTTTTT";
         let quals = b"????????@@@@@@@@@@@@##########";
-        let out: Vec<_> = rs.extract(bases, quals, false).unwrap().collect();
+        let out: Vec<_> = rs.extract(bases, quals, SkipHandling::Exclude).unwrap().collect();
         assert_eq!(out.len(), 2);
         assert_eq!(out[0].0.kind, SegmentType::MolecularBarcode);
         assert_eq!(out[1].0.kind, SegmentType::Template);
@@ -656,7 +713,7 @@ mod test {
         let rs = ReadStructure::from_str("8S+M10T").unwrap();
         let bases = b"SSSSSSSSUUUUUUUUUUUUTTTTTTTTTT";
         let quals = b"????????@@@@@@@@@@@@##########";
-        let out: Vec<_> = rs.extract(bases, quals, true).unwrap().collect();
+        let out: Vec<_> = rs.extract(bases, quals, SkipHandling::Include).unwrap().collect();
         assert_eq!(out.len(), 3);
         assert_eq!(out[0].0.kind, SegmentType::Skip);
         assert_eq!(out[0].1, b"SSSSSSSS");
@@ -665,14 +722,14 @@ mod test {
     #[test]
     fn test_extract_errors_on_bases_quals_length_mismatch() {
         let rs = ReadStructure::from_str("10T").unwrap();
-        let err = rs.extract(b"AAAAAAAAAA", b"III", true).unwrap_err();
+        let err = rs.extract(b"AAAAAAAAAA", b"III", SkipHandling::Include).unwrap_err();
         assert!(matches!(err, ReadStructureError::MismatchingBasesAndQualsLen { .. }));
     }
 
     #[test]
     fn test_extract_errors_when_read_too_short_for_fixed() {
         let rs = ReadStructure::from_str("10T8B").unwrap();
-        let err = rs.extract(b"AAAA", b"IIII", true).unwrap_err();
+        let err = rs.extract(b"AAAA", b"IIII", SkipHandling::Include).unwrap_err();
         match err {
             ReadStructureError::ReadTooShort { read_len, required } => {
                 assert_eq!(read_len, 4);
@@ -688,7 +745,7 @@ mod test {
         let rs = ReadStructure::from_str("8B+M10T").unwrap();
         let bases = vec![b'X'; 18]; // == length_of_fixed_segments
         let quals = vec![b'#'; 18];
-        let err = rs.extract(&bases, &quals, true).unwrap_err();
+        let err = rs.extract(&bases, &quals, SkipHandling::Include).unwrap_err();
         match err {
             ReadStructureError::ReadTooShort { read_len, required } => {
                 assert_eq!(read_len, 18);
@@ -703,7 +760,55 @@ mod test {
         let rs = ReadStructure::from_str("10T8B").unwrap();
         let bases = vec![b'X'; 18];
         let quals = vec![b'#'; 18];
-        let out: Vec<_> = rs.extract(&bases, &quals, true).unwrap().collect();
+        let out: Vec<_> = rs.extract(&bases, &quals, SkipHandling::Include).unwrap().collect();
         assert_eq!(out.len(), 2);
+    }
+
+    #[test]
+    fn test_extract_plus_only_structure() {
+        // Entire read is one indefinite-length template segment.
+        let rs = ReadStructure::from_str("+T").unwrap();
+        let bases = b"AAAAAAAAAA";
+        let quals = b"IIIIIIIIII";
+        let out: Vec<_> = rs.extract(bases, quals, SkipHandling::Include).unwrap().collect();
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].0.kind, SegmentType::Template);
+        assert_eq!(out[0].1, bases);
+        assert_eq!(out[0].2, quals);
+    }
+
+    #[test]
+    fn test_extract_plus_yields_one_base_at_minimum_length() {
+        // For `"8B+M10T"` the minimum read length is fixed + 1 = 19; at that length
+        // the `+M` segment must contain exactly one base.
+        let rs = ReadStructure::from_str("8B+M10T").unwrap();
+        let bases = b"BBBBBBBBMTTTTTTTTTT";
+        let quals = b"!!!!!!!!@##########";
+        assert_eq!(bases.len(), 19);
+        let out: Vec<_> = rs.extract(bases, quals, SkipHandling::Include).unwrap().collect();
+        assert_eq!(out.len(), 3);
+        assert_eq!(out[0].1, b"BBBBBBBB");
+        assert_eq!(out[1].0.kind, SegmentType::MolecularBarcode);
+        assert_eq!(out[1].1, b"M");
+        assert_eq!(out[1].2, b"@");
+        assert_eq!(out[2].1, b"TTTTTTTTTT");
+    }
+
+    #[test]
+    fn test_extract_multiple_post_plus_segments() {
+        // Two fixed segments after the `+` exercise the backward offset pass.
+        let rs = ReadStructure::from_str("8B+M5T5S").unwrap();
+        let bases = b"BBBBBBBBUUUUUUUUUUUUTTTTTSSSSS";
+        let quals = b"!!!!!!!!@@@@@@@@@@@@#####?????";
+        assert_eq!(bases.len(), 30);
+        let out: Vec<_> = rs.extract(bases, quals, SkipHandling::Include).unwrap().collect();
+        assert_eq!(out.len(), 4);
+        assert_eq!(out[0].1, b"BBBBBBBB");
+        assert_eq!(out[1].0.kind, SegmentType::MolecularBarcode);
+        assert_eq!(out[1].1, b"UUUUUUUUUUUU");
+        assert_eq!(out[2].0.kind, SegmentType::Template);
+        assert_eq!(out[2].1, b"TTTTT");
+        assert_eq!(out[3].0.kind, SegmentType::Skip);
+        assert_eq!(out[3].1, b"SSSSS");
     }
 }

--- a/src/read_structure.rs
+++ b/src/read_structure.rs
@@ -2,63 +2,74 @@
 //!
 //! Type [`ReadStructure`] describes the structure of a given read.  A read
 //! contains one or more read segments. A read segment describes a contiguous
-//! stretch of bases of the same type (e.g. template bases) of some length and
-//! some offset from the start of the read.
+//! stretch of bases of the same type (e.g. template bases).
+//!
+//! At most one segment may be the indefinite-length (`+`) segment meaning "the rest
+//! of the read"; it can appear in any position, not just the terminal one.
 
 use crate::ErrorMessageParts;
 use crate::ReadStructureError;
-use crate::read_segment;
 use crate::read_segment::ANY_LENGTH_BYTE;
 use crate::read_segment::ReadSegment;
 use crate::segment_type::SegmentType;
-use std::convert::TryFrom;
 use std::ops::Index;
-use std::string;
-use std::string::ToString;
 
-/// The read structure composed of one or more [`ReadSegment`]s.
+/// A read structure made up of one or more [`ReadSegment`]s.
+///
+/// Internally, in addition to the segments themselves, we cache per-segment start
+/// offsets (signed) and enough summary information to resolve the indefinite-length
+/// (`+`) segment's end position at extract time without another pass over the
+/// segments.
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ReadStructure {
     /// The elements that make up the [`ReadStructure`].
     elements: Vec<ReadSegment>,
-    /// The combined length of fixed length segments.
+    /// Sum of lengths across all fixed-length (non-`+`) segments.
     length_of_fixed_segments: usize,
+    /// Index of the indefinite-length (`+`) segment, if any.
+    plus_index: Option<usize>,
+    /// Sum of fixed-length-segment lengths strictly AFTER the `+` segment. Zero when
+    /// there is no `+` or when `+` is terminal. Allows the end of the `+` segment to
+    /// be located as `read_len - post_plus_len` at extract time.
+    post_plus_len: usize,
+    /// Per-element start offset.
+    ///
+    /// Sign carries the frame of reference:
+    /// - `>= 0` — offset from the start of the read. Used for segments before or
+    ///   at the `+`, and for every segment when there is no `+`.
+    /// - `<  0` — distance from the end of the read, stored as a negative number.
+    ///   Used for segments strictly after a non-terminal `+`. The actual start
+    ///   position in a read of length `L` is `L + offset` (i.e., `L - (-offset)`).
+    offsets: Vec<isize>,
 }
 
 impl ReadStructure {
     /// Builds a new [`ReadStructure`] from a vector of [`ReadSegment`]s.
     ///
-    /// At most one segment may have an indefinite length. By default that segment must
-    /// be the last one. When the `non-terminal-plus` feature is enabled, the
-    /// indefinite-length segment is also permitted in a non-terminal position; in that
-    /// case the indefinite segment and every segment following it will have their
-    /// `extractable` flag set to `false`, and calling [`ReadSegment::extract_bases`] or
-    /// [`ReadSegment::extract_bases_and_quals`] on them returns
-    /// [`ReadStructureError::SegmentNotExtractable`].
+    /// At most one segment may have an indefinite length (`+`); it may appear in any
+    /// position.
     ///
     /// # Errors
     ///
     /// - Returns `Err` if no elements exist.
     /// - Returns `Err` if more than one segment has an indefinite length.
-    /// - Without the `non-terminal-plus` feature, returns `Err` if the single
-    ///   indefinite-length segment is not the last segment.
     #[allow(clippy::missing_panics_doc)]
-    pub fn new(mut segments: Vec<ReadSegment>) -> Result<Self, ReadStructureError> {
+    pub fn new(segments: Vec<ReadSegment>) -> Result<Self, ReadStructureError> {
         if segments.is_empty() {
             return Err(ReadStructureError::ReadStructureContainsZeroElements);
         }
 
         let mut num_indefinite = 0;
         let mut length_of_fixed_segments = 0;
-        let mut indefinite_index: Option<usize> = None;
+        let mut plus_index: Option<usize> = None;
         for (i, s) in segments.iter().enumerate() {
             if let Some(len) = s.length {
                 length_of_fixed_segments += len;
             } else {
                 num_indefinite += 1;
-                if indefinite_index.is_none() {
-                    indefinite_index = Some(i);
+                if plus_index.is_none() {
+                    plus_index = Some(i);
                 }
             }
         }
@@ -69,39 +80,98 @@ impl ReadStructure {
             ));
         }
 
-        #[cfg(not(feature = "non-terminal-plus"))]
-        if let Some(idx) = indefinite_index {
-            if idx != segments.len() - 1 {
-                return Err(
-                    ReadStructureError::ReadStructureNonTerminalIndefiniteLengthReadSegment(
-                        segments[idx],
-                    ),
-                );
-            }
-        }
+        // Compute per-element offsets. Two-pass: forward for pre-and-at-`+` (and
+        // for every segment when there is no `+`), then backward for segments
+        // strictly after the `+`.
+        let n = segments.len();
+        let mut offsets = vec![0isize; n];
 
+        // Forward pass up to and including the `+` (or the whole vec if no `+`).
+        let forward_end = plus_index.map_or(n, |p| p + 1);
         let mut off: usize = 0;
-        for segment in &mut segments {
-            segment.offset = off;
-            off += segment.length.unwrap_or(0);
+        for (i, seg) in segments.iter().take(forward_end).enumerate() {
+            offsets[i] = off as isize;
+            off += seg.length.unwrap_or(0);
         }
 
-        #[cfg(feature = "non-terminal-plus")]
-        if let Some(idx) = indefinite_index {
-            if idx != segments.len() - 1 {
-                for segment in &mut segments[idx..] {
-                    segment.extractable = false;
-                }
+        // Backward pass for segments strictly after the `+`, if any.
+        let mut post_plus_len: usize = 0;
+        if let Some(p) = plus_index {
+            // `dist_from_end` is the total number of bases from the *start* of the
+            // current segment to the end of the read. We walk from the end back.
+            let mut dist_from_end: usize = 0;
+            for (i, seg) in segments.iter().enumerate().skip(p + 1).rev() {
+                // Fixed length — invariants: non-`+` segments always have a length.
+                let len = seg.length.expect("post-+ segments must be fixed length");
+                dist_from_end += len;
+                offsets[i] = -(dist_from_end as isize);
             }
+            post_plus_len = dist_from_end;
         }
 
-        Ok(ReadStructure { elements: segments, length_of_fixed_segments })
+        Ok(ReadStructure {
+            elements: segments,
+            length_of_fixed_segments,
+            plus_index,
+            post_plus_len,
+            offsets,
+        })
+    }
+
+    /// Extracts the bases and quality scores for every segment in this read structure.
+    ///
+    /// Returns a no-alloc iterator over `(&ReadSegment, &[u8] bases, &[u8] quals)` triples.
+    /// All error conditions are checked up front, so the returned iterator is infallible
+    /// and can be cheaply `.collect()`ed into a `Vec` when an owned collection is needed.
+    ///
+    /// When `include_skips` is `false`, segments of type [`SegmentType::Skip`] are
+    /// omitted from the output.
+    ///
+    /// # Errors
+    ///
+    /// - [`ReadStructureError::MismatchingBasesAndQualsLen`] if `bases.len() != quals.len()`.
+    /// - [`ReadStructureError::ReadTooShort`] if the read cannot accommodate every fixed
+    ///   segment. When the structure also has a `+` segment, the read must be strictly
+    ///   longer than the sum of the fixed-segment lengths (since `+` means at least
+    ///   one base).
+    pub fn extract<'rs, 'b>(
+        &'rs self,
+        bases: &'b [u8],
+        quals: &'b [u8],
+        include_skips: bool,
+    ) -> Result<ExtractedSegments<'rs, 'b>, ReadStructureError> {
+        if bases.len() != quals.len() {
+            return Err(ReadStructureError::MismatchingBasesAndQualsLen {
+                bases_len: bases.len(),
+                quals_len: quals.len(),
+            });
+        }
+
+        let required = if self.plus_index.is_some() {
+            self.length_of_fixed_segments + 1
+        } else {
+            self.length_of_fixed_segments
+        };
+        if bases.len() < required {
+            return Err(ReadStructureError::ReadTooShort { read_len: bases.len(), required });
+        }
+
+        Ok(ExtractedSegments {
+            elements: &self.elements,
+            offsets: &self.offsets,
+            plus_index: self.plus_index,
+            post_plus_len: self.post_plus_len,
+            bases,
+            quals,
+            include_skips,
+            next_index: 0,
+        })
     }
 
     /// Returns `true` if the [`ReadStructure`] has a fixed (i.e. non-variable) length,
     /// `false` if any segment has an indefinite length.
     pub fn has_fixed_length(&self) -> bool {
-        self.elements.iter().all(ReadSegment::has_length)
+        self.plus_index.is_none()
     }
 
     /// Returns the fixed length if there is one.
@@ -119,7 +189,7 @@ impl ReadStructure {
         &self.elements
     }
 
-    /// Returns an iterator over the read segments
+    /// Returns an iterator over the read segments.
     pub fn iter(&self) -> impl Iterator<Item = &ReadSegment> {
         self.elements.iter()
     }
@@ -129,39 +199,86 @@ impl ReadStructure {
         self.elements.iter().filter(move |seg| seg.kind == kind)
     }
 
-    /// Returns the template [`ReadSegment`]s in this read structure
+    /// Returns the template [`ReadSegment`]s in this read structure.
     pub fn templates(&self) -> impl Iterator<Item = &ReadSegment> {
         self.segments_by_type(SegmentType::Template)
     }
 
-    /// Returns the sample barcode [`ReadSegment`]s in this read structure
+    /// Returns the sample barcode [`ReadSegment`]s in this read structure.
     pub fn sample_barcodes(&self) -> impl Iterator<Item = &ReadSegment> {
         self.segments_by_type(SegmentType::SampleBarcode)
     }
 
-    /// Returns the molecular barcode [`ReadSegment`]s in this read structure
+    /// Returns the molecular barcode [`ReadSegment`]s in this read structure.
     pub fn molecular_barcodes(&self) -> impl Iterator<Item = &ReadSegment> {
         self.segments_by_type(SegmentType::MolecularBarcode)
     }
 
-    /// Returns the skip [`ReadSegment`]s in this read structure
+    /// Returns the skip [`ReadSegment`]s in this read structure.
     pub fn skips(&self) -> impl Iterator<Item = &ReadSegment> {
         self.segments_by_type(SegmentType::Skip)
     }
 
-    /// Returns the cellular barcode [`ReadSegment`]s in this read structure
+    /// Returns the cellular barcode [`ReadSegment`]s in this read structure.
     pub fn cellular_barcodes(&self) -> impl Iterator<Item = &ReadSegment> {
         self.segments_by_type(SegmentType::CellularBarcode)
     }
 
-    /// Returns the first [`ReadSegment`] in this read structure
+    /// Returns the first [`ReadSegment`] in this read structure.
     pub fn first(&self) -> Option<&ReadSegment> {
         self.elements.first()
     }
 
-    /// Returns the last [`ReadSegment`] in this read structure
+    /// Returns the last [`ReadSegment`] in this read structure.
     pub fn last(&self) -> Option<&ReadSegment> {
         self.elements.last()
+    }
+}
+
+/// Iterator returned by [`ReadStructure::extract`].
+///
+/// Yields `(&ReadSegment, &[u8] bases, &[u8] quals)` triples — one per segment in
+/// the underlying read structure, in order (with `Skip` segments optionally filtered).
+/// The iterator is infallible: all error checks are performed up front in
+/// [`ReadStructure::extract`].
+#[derive(Debug)]
+pub struct ExtractedSegments<'rs, 'b> {
+    elements: &'rs [ReadSegment],
+    offsets: &'rs [isize],
+    plus_index: Option<usize>,
+    post_plus_len: usize,
+    bases: &'b [u8],
+    quals: &'b [u8],
+    include_skips: bool,
+    next_index: usize,
+}
+
+impl<'rs, 'b> Iterator for ExtractedSegments<'rs, 'b> {
+    type Item = (&'rs ReadSegment, &'b [u8], &'b [u8]);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while self.next_index < self.elements.len() {
+            let i = self.next_index;
+            self.next_index += 1;
+            let seg = &self.elements[i];
+            if !self.include_skips && seg.kind == SegmentType::Skip {
+                continue;
+            }
+            let (start, end) = if Some(i) == self.plus_index {
+                // The indefinite-length segment: runs from its stored start offset
+                // to just before the post-`+` fixed region.
+                (self.offsets[i] as usize, self.bases.len() - self.post_plus_len)
+            } else {
+                let off = self.offsets[i];
+                let start =
+                    if off >= 0 { off as usize } else { self.bases.len() - ((-off) as usize) };
+                // Non-`+` segments always have a fixed length.
+                let len = seg.length.expect("non-`+` segment must have a length");
+                (start, start + len)
+            };
+            return Some((seg, &self.bases[start..end], &self.quals[start..end]));
+        }
+        None
     }
 }
 
@@ -199,7 +316,6 @@ impl std::str::FromStr for ReadStructure {
 
     /// Returns a new read structure from a string, or `Err` if parsing failed.
     fn from_str(rs: &str) -> Result<Self, Self::Err> {
-        let mut offset = 0;
         let mut i = 0;
         let mut segs: Vec<ReadSegment> = Vec::new();
         let chars: Vec<char> = rs.to_uppercase().chars().filter(|c| !c.is_whitespace()).collect();
@@ -238,14 +354,7 @@ impl std::str::FromStr for ReadStructure {
                     )));
                 }
                 i += 1;
-                segs.push(ReadSegment {
-                    offset,
-                    length,
-                    kind,
-                    #[cfg(feature = "non-terminal-plus")]
-                    extractable: true,
-                });
-                offset += length.unwrap_or(0);
+                segs.push(ReadSegment { length, kind });
             } else {
                 return Err(ReadStructureError::ReadStructureHadUnknownType(
                     ErrorMessageParts::new(&chars, parse_i, i + 1),
@@ -267,7 +376,9 @@ impl TryFrom<&[ReadSegment]> for ReadStructure {
 
 #[cfg(test)]
 mod test {
+    use crate::ReadStructureError;
     use crate::read_structure::ReadStructure;
+    use crate::segment_type::SegmentType;
     use std::str::FromStr;
 
     #[test]
@@ -305,18 +416,11 @@ mod test {
     }
 
     test_read_structure_from_str_err! {
-        test_read_structure_allow_any_char_only_once_and_for_last_segment_panic_0: "++M",
-        test_read_structure_allow_any_char_only_once_and_for_last_segment_panic_1: "5M++T",
-        test_read_structure_allow_any_char_only_once_and_for_last_segment_panic_2: "5M70+T",
-        test_read_structure_allow_any_char_only_once_and_for_last_segment_panic_3: "+M+T",
-    }
-
-    // With the `non-terminal-plus` feature enabled, this is a legal read structure.
-    // Tested for acceptance in the feature-gated test module below.
-    #[test]
-    #[cfg(not(feature = "non-terminal-plus"))]
-    fn test_read_structure_strict_rejects_non_terminal_plus() {
-        assert!(ReadStructure::from_str("+M70T").is_err());
+        test_read_structure_rejects_multiple_plus_0: "++M",
+        test_read_structure_rejects_multiple_plus_1: "5M++T",
+        test_read_structure_rejects_multiple_plus_2: "5M70+T",
+        test_read_structure_rejects_multiple_plus_3: "+M+T",
+        test_read_structure_rejects_multiple_plus_4: "5M+T+B",
     }
 
     macro_rules! test_read_structure_from_str_invalid {
@@ -384,31 +488,30 @@ mod test {
         $(
             #[test]
             fn $name() {
-                let (string, index, exp_string, exp_offset) = $value;
+                let (string, index, exp_string) = $value;
                 let read_structure = ReadStructure::from_str(string).unwrap();
                 let read_segment = read_structure[index];
                 assert_eq!(read_segment.to_string(), exp_string);
-                assert_eq!(read_segment.offset, exp_offset);
             }
         )*
         }
     }
 
     test_read_structure_index! {
-        test_read_structure_index_0: ("1T", 0, "1T", 0),
-        test_read_structure_index_1: ("1B", 0, "1B", 0),
-        test_read_structure_index_2: ("1M", 0, "1M", 0),
-        test_read_structure_index_3: ("1S", 0, "1S", 0),
-        test_read_structure_index_4: ("101T", 0, "101T", 0),
-        test_read_structure_index_5: ("5B101T", 0, "5B", 0),
-        test_read_structure_index_6: ("5B101T", 1, "101T", 5),
-        test_read_structure_index_7: ("123456789T", 0, "123456789T", 0),
-        test_read_structure_index_8: ("10T10B10B10S10M", 0, "10T", 0),
-        test_read_structure_index_9: ("10T10B10B10S10M", 1, "10B", 10),
-        test_read_structure_index_10: ("10T10B10B10S10M", 2, "10B", 20),
-        test_read_structure_index_11: ("10T10B10B10S10M", 3, "10S", 30),
-        test_read_structure_index_12: ("10T10B10B10S10M", 4, "10M", 40),
-        test_read_structure_index_32: ("10T10B10B10S10C10M", 4, "10C", 40),
+        test_read_structure_index_0: ("1T", 0, "1T"),
+        test_read_structure_index_1: ("1B", 0, "1B"),
+        test_read_structure_index_2: ("1M", 0, "1M"),
+        test_read_structure_index_3: ("1S", 0, "1S"),
+        test_read_structure_index_4: ("101T", 0, "101T"),
+        test_read_structure_index_5: ("5B101T", 0, "5B"),
+        test_read_structure_index_6: ("5B101T", 1, "101T"),
+        test_read_structure_index_7: ("123456789T", 0, "123456789T"),
+        test_read_structure_index_8: ("10T10B10B10S10M", 0, "10T"),
+        test_read_structure_index_9: ("10T10B10B10S10M", 1, "10B"),
+        test_read_structure_index_10: ("10T10B10B10S10M", 2, "10B"),
+        test_read_structure_index_11: ("10T10B10B10S10M", 3, "10S"),
+        test_read_structure_index_12: ("10T10B10B10S10M", 4, "10M"),
+        test_read_structure_index_32: ("10T10B10B10S10C10M", 4, "10C"),
     }
 
     #[test]
@@ -420,110 +523,187 @@ mod test {
         assert_eq!(rs, rs2);
     }
 
-    // ---- tests covering the `non-terminal-plus` feature ----
+    // ---- non-terminal `+` acceptance (parsing + round-trip) ----
 
-    #[cfg(feature = "non-terminal-plus")]
-    mod non_terminal_plus {
-        use crate::ReadStructureError;
-        use crate::read_structure::ReadStructure;
-        use std::str::FromStr;
+    #[test]
+    fn test_accepts_middle_plus() {
+        let rs = ReadStructure::from_str("8B+M10T").unwrap();
+        assert_eq!(rs.to_string(), "8B+M10T");
+        assert_eq!(rs.number_of_segments(), 3);
+    }
 
-        #[test]
-        fn test_accepts_middle_plus() {
-            let rs = ReadStructure::from_str("8B+M10T").unwrap();
-            assert_eq!(rs.to_string(), "8B+M10T");
-            assert_eq!(rs.number_of_segments(), 3);
+    #[test]
+    fn test_accepts_leading_plus() {
+        let rs = ReadStructure::from_str("+B10T").unwrap();
+        assert_eq!(rs.to_string(), "+B10T");
+        assert_eq!(rs.number_of_segments(), 2);
+    }
+
+    #[test]
+    fn test_accepts_middle_plus_between_fixed_runs() {
+        let rs = ReadStructure::from_str("10T8B+M10T").unwrap();
+        assert_eq!(rs.to_string(), "10T8B+M10T");
+        assert_eq!(rs.number_of_segments(), 4);
+    }
+
+    // ---- has_fixed_length / fixed_length ----
+
+    #[test]
+    fn test_has_fixed_length_strict() {
+        assert!(ReadStructure::from_str("10T8B").unwrap().has_fixed_length());
+        assert!(!ReadStructure::from_str("10T+M").unwrap().has_fixed_length());
+    }
+
+    #[test]
+    fn test_has_fixed_length_middle_plus() {
+        assert!(!ReadStructure::from_str("8B+M10T").unwrap().has_fixed_length());
+    }
+
+    #[test]
+    fn test_fixed_length_none_for_middle_plus() {
+        assert!(ReadStructure::from_str("8B+M10T").unwrap().fixed_length().is_none());
+    }
+
+    // ---- extraction via ReadStructure::extract ----
+
+    #[test]
+    fn test_extract_fixed_length() {
+        let rs = ReadStructure::from_str("10T8B").unwrap();
+        let bases = b"AAAAAAAAAAGGGGGGGG";
+        let quals = b"IIIIIIIIIIJJJJJJJJ";
+        let out: Vec<_> = rs.extract(bases, quals, true).unwrap().collect();
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0].0.kind, SegmentType::Template);
+        assert_eq!(out[0].1, b"AAAAAAAAAA");
+        assert_eq!(out[0].2, b"IIIIIIIIII");
+        assert_eq!(out[1].0.kind, SegmentType::SampleBarcode);
+        assert_eq!(out[1].1, b"GGGGGGGG");
+        assert_eq!(out[1].2, b"JJJJJJJJ");
+    }
+
+    #[test]
+    fn test_extract_trailing_plus() {
+        let rs = ReadStructure::from_str("10T+M").unwrap();
+        let bases = b"AAAAAAAAAAGGGGGGGGGG";
+        let quals = b"IIIIIIIIIIJJJJJJJJJJ";
+        let out: Vec<_> = rs.extract(bases, quals, true).unwrap().collect();
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0].1, b"AAAAAAAAAA");
+        assert_eq!(out[1].1, b"GGGGGGGGGG");
+        assert_eq!(out[1].2, b"JJJJJJJJJJ");
+    }
+
+    #[test]
+    fn test_extract_leading_plus() {
+        let rs = ReadStructure::from_str("+B10T").unwrap();
+        let bases = b"BBBBBTTTTTTTTTT";
+        let quals = b"!!!!!##########";
+        let out: Vec<_> = rs.extract(bases, quals, true).unwrap().collect();
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0].0.kind, SegmentType::SampleBarcode);
+        assert_eq!(out[0].1, b"BBBBB");
+        assert_eq!(out[0].2, b"!!!!!");
+        assert_eq!(out[1].0.kind, SegmentType::Template);
+        assert_eq!(out[1].1, b"TTTTTTTTTT");
+        assert_eq!(out[1].2, b"##########");
+    }
+
+    #[test]
+    fn test_extract_middle_plus() {
+        let rs = ReadStructure::from_str("8B+M10T").unwrap();
+        let bases = b"BBBBBBBBUUUUUUUUUUUUTTTTTTTTTT";
+        let quals = b"!!!!!!!!@@@@@@@@@@@@##########";
+        assert_eq!(bases.len(), 30);
+        let out: Vec<_> = rs.extract(bases, quals, true).unwrap().collect();
+        assert_eq!(out.len(), 3);
+        assert_eq!(out[0].1, b"BBBBBBBB");
+        assert_eq!(out[0].2, b"!!!!!!!!");
+        assert_eq!(out[1].0.kind, SegmentType::MolecularBarcode);
+        assert_eq!(out[1].1, b"UUUUUUUUUUUU");
+        assert_eq!(out[1].2, b"@@@@@@@@@@@@");
+        assert_eq!(out[2].1, b"TTTTTTTTTT");
+        assert_eq!(out[2].2, b"##########");
+    }
+
+    #[test]
+    fn test_extract_multiple_pre_plus_and_post_plus() {
+        // Two pre-plus, one middle plus, one post-plus.
+        let rs = ReadStructure::from_str("10T8B+M10T").unwrap();
+        let bases = b"TTTTTTTTTTBBBBBBBBUUUUUUUUUUUUTTTTTTTTTT";
+        let quals = b"IIIIIIIIII!!!!!!!!@@@@@@@@@@@@##########";
+        assert_eq!(bases.len(), 40);
+        let out: Vec<_> = rs.extract(bases, quals, true).unwrap().collect();
+        assert_eq!(out.len(), 4);
+        assert_eq!(out[0].1, b"TTTTTTTTTT");
+        assert_eq!(out[1].1, b"BBBBBBBB");
+        assert_eq!(out[2].1, b"UUUUUUUUUUUU");
+        assert_eq!(out[3].1, b"TTTTTTTTTT");
+    }
+
+    #[test]
+    fn test_extract_include_skips_false_drops_skip() {
+        let rs = ReadStructure::from_str("8S+M10T").unwrap();
+        let bases = b"SSSSSSSSUUUUUUUUUUUUTTTTTTTTTT";
+        let quals = b"????????@@@@@@@@@@@@##########";
+        let out: Vec<_> = rs.extract(bases, quals, false).unwrap().collect();
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0].0.kind, SegmentType::MolecularBarcode);
+        assert_eq!(out[1].0.kind, SegmentType::Template);
+    }
+
+    #[test]
+    fn test_extract_include_skips_true_keeps_skip() {
+        let rs = ReadStructure::from_str("8S+M10T").unwrap();
+        let bases = b"SSSSSSSSUUUUUUUUUUUUTTTTTTTTTT";
+        let quals = b"????????@@@@@@@@@@@@##########";
+        let out: Vec<_> = rs.extract(bases, quals, true).unwrap().collect();
+        assert_eq!(out.len(), 3);
+        assert_eq!(out[0].0.kind, SegmentType::Skip);
+        assert_eq!(out[0].1, b"SSSSSSSS");
+    }
+
+    #[test]
+    fn test_extract_errors_on_bases_quals_length_mismatch() {
+        let rs = ReadStructure::from_str("10T").unwrap();
+        let err = rs.extract(b"AAAAAAAAAA", b"III", true).unwrap_err();
+        assert!(matches!(err, ReadStructureError::MismatchingBasesAndQualsLen { .. }));
+    }
+
+    #[test]
+    fn test_extract_errors_when_read_too_short_for_fixed() {
+        let rs = ReadStructure::from_str("10T8B").unwrap();
+        let err = rs.extract(b"AAAA", b"IIII", true).unwrap_err();
+        match err {
+            ReadStructureError::ReadTooShort { read_len, required } => {
+                assert_eq!(read_len, 4);
+                assert_eq!(required, 18);
+            }
+            other => panic!("expected ReadTooShort, got {:?}", other),
         }
+    }
 
-        #[test]
-        fn test_accepts_leading_plus() {
-            let rs = ReadStructure::from_str("+B10T").unwrap();
-            assert_eq!(rs.to_string(), "+B10T");
-            assert_eq!(rs.number_of_segments(), 2);
+    #[test]
+    fn test_extract_errors_when_read_exactly_fixed_len_but_plus_present() {
+        // `+` requires at least one base, so read length must exceed fixed-length total.
+        let rs = ReadStructure::from_str("8B+M10T").unwrap();
+        let bases = vec![b'X'; 18]; // == length_of_fixed_segments
+        let quals = vec![b'#'; 18];
+        let err = rs.extract(&bases, &quals, true).unwrap_err();
+        match err {
+            ReadStructureError::ReadTooShort { read_len, required } => {
+                assert_eq!(read_len, 18);
+                assert_eq!(required, 19);
+            }
+            other => panic!("expected ReadTooShort, got {:?}", other),
         }
+    }
 
-        #[test]
-        fn test_accepts_trailing_plus() {
-            // Trailing `+` is still legal (it was before and it is now).
-            let rs = ReadStructure::from_str("10T+M").unwrap();
-            assert_eq!(rs.to_string(), "10T+M");
-        }
-
-        #[test]
-        fn test_accepts_middle_plus_between_fixed_runs() {
-            let rs = ReadStructure::from_str("10T8B+M10T").unwrap();
-            assert_eq!(rs.to_string(), "10T8B+M10T");
-            assert_eq!(rs.number_of_segments(), 4);
-        }
-
-        #[test]
-        fn test_rejects_two_consecutive_plus() {
-            assert!(ReadStructure::from_str("++M").is_err());
-        }
-
-        #[test]
-        fn test_rejects_two_separate_plus() {
-            assert!(ReadStructure::from_str("+M+T").is_err());
-        }
-
-        #[test]
-        fn test_rejects_two_plus_in_longer_structure() {
-            assert!(ReadStructure::from_str("5M+T+B").is_err());
-        }
-
-        #[test]
-        fn test_pre_plus_segments_still_extract() {
-            let rs = ReadStructure::from_str("8B+M10T").unwrap();
-            let read = b"BBBBBBBBUUUUUUUUUUUUTTTTTTTTTT";
-            assert_eq!(rs.segments()[0].extract_bases(read).unwrap(), b"BBBBBBBB");
-        }
-
-        #[test]
-        fn test_middle_plus_segment_not_extractable() {
-            let rs = ReadStructure::from_str("8B+M10T").unwrap();
-            let read = b"BBBBBBBBUUUUUUUUUUUUTTTTTTTTTT";
-            let err = rs.segments()[1].extract_bases(read).unwrap_err();
-            assert!(matches!(err, ReadStructureError::SegmentNotExtractable(_)));
-        }
-
-        #[test]
-        fn test_post_plus_segment_not_extractable() {
-            let rs = ReadStructure::from_str("8B+M10T").unwrap();
-            let read = b"BBBBBBBBUUUUUUUUUUUUTTTTTTTTTT";
-            let err = rs.segments()[2].extract_bases(read).unwrap_err();
-            assert!(matches!(err, ReadStructureError::SegmentNotExtractable(_)));
-        }
-
-        #[test]
-        fn test_extract_bases_and_quals_errors_on_post_plus() {
-            let rs = ReadStructure::from_str("8B+M10T").unwrap();
-            let bases = b"BBBBBBBBUUUUUUUUUUUUTTTTTTTTTT";
-            let quals = b"##########################????";
-            let err = rs.segments()[2].extract_bases_and_quals(bases, quals).unwrap_err();
-            assert!(matches!(err, ReadStructureError::SegmentNotExtractable(_)));
-        }
-
-        #[test]
-        fn test_trailing_plus_still_extractable() {
-            // Terminal `+` must remain extractable under the feature.
-            let rs = ReadStructure::from_str("10T+M").unwrap();
-            let read = b"AAAAAAAAAAGGGGGGGGGG";
-            assert_eq!(rs.segments()[1].extract_bases(read).unwrap(), b"GGGGGGGGGG");
-        }
-
-        #[test]
-        fn test_has_fixed_length_middle_plus() {
-            assert!(!ReadStructure::from_str("8B+M10T").unwrap().has_fixed_length());
-        }
-
-        #[test]
-        fn test_has_fixed_length_no_plus() {
-            assert!(ReadStructure::from_str("10T10B").unwrap().has_fixed_length());
-        }
-
-        #[test]
-        fn test_fixed_length_none_for_middle_plus() {
-            assert!(ReadStructure::from_str("8B+M10T").unwrap().fixed_length().is_none());
-        }
+    #[test]
+    fn test_extract_allows_read_exactly_fixed_len_when_no_plus() {
+        let rs = ReadStructure::from_str("10T8B").unwrap();
+        let bases = vec![b'X'; 18];
+        let quals = vec![b'#'; 18];
+        let out: Vec<_> = rs.extract(&bases, &quals, true).unwrap().collect();
+        assert_eq!(out.len(), 2);
     }
 }

--- a/src/segment_type.rs
+++ b/src/segment_type.rs
@@ -13,7 +13,6 @@ use crate::ReadStructureError;
 /// The `SegmentType` type. See [the module level documentation](self) for more.
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, EnumIter, PartialEq, Eq, Hash, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(u8)]
 pub enum SegmentType {
     /// Template: the bases in the segment are reads of template (e.g. genomic dna, rna, etc.)


### PR DESCRIPTION
Existing `ReadStructure::from_str` / `::new` only accept the `+` (indefinite-length) segment as the final segment. This adds opt-in `ReadStructure::from_str_relaxed` and `ReadStructure::new_relaxed` which additionally allow `+` in a non-terminal position. The "only one `+` per structure" rule is preserved in both modes, and strict behavior is bit-for-bit unchanged.

Extraction is deliberately not supported for middle-`+` structures: a new `ReadSegment.extractable` flag (false for the `+` segment and everything after it when `+` is non-terminal) causes `extract_bases` and `extract_bases_and_quals` to return a new `ReadStructureError::SegmentNotExtractable` error. Resolving offsets against a specific read length is left for a follow-up if callers need it.

Also fixes `has_fixed_length` to scan all segments rather than key off the last one, so it reports correctly for middle-`+` structures.